### PR TITLE
Fix boot problems with sixad

### DIFF
--- a/sixad
+++ b/sixad
@@ -12,12 +12,6 @@ trap "exit" SIGHUP SIGINT SIGTERM
 
 . /etc/default/sixad
 
-if [ -f /usr/bin/sudo ]; then
-  SUDO="/usr/bin/sudo"
-else
-  SUDO=""
-fi
-
 bt_device_checkr() {
 if (! hciconfig dev &> /dev/null); then
     return 0;
@@ -42,12 +36,21 @@ if (which hciconfig > /dev/null); then
     echo "You're using a _really_ old bluetooth dongle,"
     echo "the Sixaxis will just not work!"
   fi
+  bt_device_enable
 fi
 }
 
 bt_device_enable () {
-$SUDO hciconfig hci0 up
-$SUDO hciconfig hci0 pscan
+bt_device_up
+bt_device_pscan
+}
+
+bt_device_up () {
+hciconfig hci0 up
+}
+
+bt_device_pscan () {
+hciconfig hci0 pscan
 }
 
 sixad_running_check () {
@@ -58,25 +61,29 @@ bluetoothd_running_check () {
 ps -e | grep bluetoothd > /dev/null
 }
 
-modprobe_check () {
-$SUDO /sbin/modprobe uinput
+isroot_check () {
+# check, if sudo is used
+if [[ $(id -u) -ne 0 ]]; then
+    echo "Script must be run as root. Try 'sudo $0'"
+    exit 1
+fi
 }
 
 bt_start () {
-$SUDO chmod 755 "$BLUETOOTHD"
+chmod 755 "$BLUETOOTHD"
 if [ -f /lib/udev/rules.d/97-bluetooth-hid2hci.rules ]; then
-  $SUDO /usr/sbin/bluetoothd --udev
+  /usr/sbin/bluetoothd --udev
 elif [ -f /etc/rc.d/bluetooth ]; then
-  $SUDO /etc/rc.d/bluetooth start
+  /etc/rc.d/bluetooth start
 else
-  $SUDO /etc/init.d/bluetooth start
+  /etc/init.d/bluetooth start
 fi
 }
 
 bt_stop() {
-$SUDO chmod 644 "$BLUETOOTHD"
+chmod 644 "$BLUETOOTHD"
 if (bluetoothd_running_check); then
-  $SUDO pkill -KILL bluetoothd
+  pkill -KILL bluetoothd
 fi
 }
 
@@ -91,104 +98,104 @@ sixad_watchdog (){
     while (true); do
         if (bt_device_checkr); then
             echo "Watchdog: Bluetooth disconnected, killing sixad."
-            $SUDO pkill -KILL sixad-sixaxis
-            $SUDO pkill -KILL sixad-remote
-            $SUDO pkill -TERM sixad-bin
-            bt_start
-            sixad_start
-        else
-            if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
-            echo "Watchdog: hci0 down, re-enabling."
-                bt_device_enable
-            fi
+            pkill -KILL sixad-sixaxis
+            pkill -KILL sixad-remote
+            pkill -TERM sixad-bin
+            break
+        fi
+        if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
+          echo "Watchdog: hci0 down, re-enabling."
+          bt_device_up
+        fi
+        if ! (hciconfig hci0 | grep "PSCAN" &> /dev/null); then
+          echo "Watchdog: PSCAN not set, resetting."
+          bt_device_pscan
         fi
         sleep 5;
     done
+    sixad_start
 }
 
 sixad_start () {
-    REMOTE=0
     bt_device_check
-    if (sixad_running_check); then
-        echo "sixad is already running."
-        echo "run '$0 --stop' to stop it"
-    else
-        if (modprobe_check); then  #Check for root access before running, If NO access, quit
-            bt_start_and_stop
-            env sleep 5
-            bt_device_enable 
-            $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
-            env sleep 2
-            sixad_watchdog
-        else
-            echo "You need admin/root access to run this application"
-        fi
-    fi
+    bt_start_and_stop
+    env sleep 1
+    /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
+    env sleep 2
+    bt_device_enable
+    sixad_watchdog
 }
 
 case $1 in
-
   --start|-start|start|-s)
-sixad_start
-  ;;
-
-  --stop|-stop|stop)
-$SUDO pkill -KILL sixad-sixaxis
-$SUDO pkill -KILL sixad-remote
-$SUDO pkill -TERM sixad-bin
-bt_start
-env sleep 1
-$SUDO pkill -TERM sixad
-  ;;
-
-  --remote|-remote|remote)
-REMOTE=1
+isroot_check
+#boot error fix attempt.
+REMOTE=0
 bt_device_check
-if (modprobe_check); then  #Check for root access before running, If NO access, quit
-  bt_start_and_stop
-  env sleep 1
-  bt_device_enable
-  $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE
-  env sleep 2
-  sixad_watchdog
+if (sixad_running_check); then
+  echo "sixad is already running."
+  echo "run '$0 --stop' to stop it"
 else
-  echo "You need admin/root access to run this application"
+  sixad_start
 fi
   ;;
 
+  --stop|-stop|stop)
+isroot_check
+pkill -KILL sixad-sixaxis
+pkill -KILL sixad-remote
+pkill -TERM sixad-bin
+bt_start
+env sleep 1
+pkill -TERM sixad
+  ;;
+
+  --remote|-remote|remote)
+isroot_check
+REMOTE=1
+bt_device_check
+bt_start_and_stop
+/usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE
+env sleep 2
+sixad_watchdog
+  ;;
+
   --restore|-restore|restore|-r)
+isroot_check
 bt_start
   ;;
 
   --boot-yes)
+isroot_check
 # ArchLinux
 if [ -f /etc/arch-release ]; then
-  $SUDO sed '/DAEMONS=/ s/)/ sixad)/g' -i /etc/rc.conf
+  sed '/DAEMONS=/ s/)/ sixad)/g' -i /etc/rc.conf
 # Gentoo
 elif [ -f /etc/gentoo-release ]; then
-  $SUDO rc-update add sixad
+  rc-update add sixad
 # Debian (default)
 else
-  if [ -f /etc/rc2.d/S90sixad ]; then true; else $SUDO ln -s /etc/init.d/sixad /etc/rc2.d/S90sixad; fi
-  if [ -f /etc/rc3.d/S90sixad ]; then true; else $SUDO ln -s /etc/init.d/sixad /etc/rc3.d/S90sixad; fi
-  if [ -f /etc/rc4.d/S90sixad ]; then true; else $SUDO ln -s /etc/init.d/sixad /etc/rc4.d/S90sixad; fi
-  if [ -f /etc/rc5.d/S90sixad ]; then true; else $SUDO ln -s /etc/init.d/sixad /etc/rc5.d/S90sixad; fi
+  if [ -f /etc/rc2.d/S90sixad ]; then true; else ln -s /etc/init.d/sixad /etc/rc2.d/S90sixad; fi
+  if [ -f /etc/rc3.d/S90sixad ]; then true; else ln -s /etc/init.d/sixad /etc/rc3.d/S90sixad; fi
+  if [ -f /etc/rc4.d/S90sixad ]; then true; else ln -s /etc/init.d/sixad /etc/rc4.d/S90sixad; fi
+  if [ -f /etc/rc5.d/S90sixad ]; then true; else ln -s /etc/init.d/sixad /etc/rc5.d/S90sixad; fi
 fi
   ;;
 
   --boot-no)
+isroot_check
 # ArchLinux
 if [ -f /etc/arch-release ]; then
-  $SUDO sed "s/ sixad//" -i /etc/rc.conf
+  sed "s/ sixad//" -i /etc/rc.conf
 # Gentoo
 elif [ -f /etc/gentoo-release ]; then
-  $SUDO rc-update delete sixad
+  rc-update delete sixad
 # Debian (default)
 else
-  if [ -f /etc/rc2.d/S90sixad ]; then $SUDO rm /etc/rc2.d/S90sixad; fi
-  if [ -f /etc/rc3.d/S90sixad ]; then $SUDO rm /etc/rc3.d/S90sixad; fi
-  if [ -f /etc/rc4.d/S90sixad ]; then $SUDO rm /etc/rc4.d/S90sixad; fi
-  if [ -f /etc/rc5.d/S90sixad ]; then $SUDO rm /etc/rc5.d/S90sixad; fi
+  if [ -f /etc/rc2.d/S90sixad ]; then rm /etc/rc2.d/S90sixad; fi
+  if [ -f /etc/rc3.d/S90sixad ]; then rm /etc/rc3.d/S90sixad; fi
+  if [ -f /etc/rc4.d/S90sixad ]; then rm /etc/rc4.d/S90sixad; fi
+  if [ -f /etc/rc5.d/S90sixad ]; then rm /etc/rc5.d/S90sixad; fi
 fi
   ;;
 

--- a/sixad
+++ b/sixad
@@ -42,20 +42,11 @@ if (which hciconfig > /dev/null); then
     echo "You're using a _really_ old bluetooth dongle,"
     echo "the Sixaxis will just not work!"
   fi
-  bt_device_enable
 fi
 }
 
 bt_device_enable () {
-bt_device_up
-bt_device_pscan
-}
-
-bt_device_up () {
 hciconfig hci0 up
-}
-
-bt_device_pscan () {
 hciconfig hci0 pscan
 }
 
@@ -103,45 +94,42 @@ sixad_watchdog (){
             $SUDO pkill -KILL sixad-sixaxis
             $SUDO pkill -KILL sixad-remote
             $SUDO pkill -TERM sixad-bin
-            break
-        fi
-        if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
-          echo "Watchdog: hci0 down, re-enabling."
-          bt_device_up
-        fi
-        if ! (hciconfig hci0 | grep "PSCAN" &> /dev/null); then
-         bt_device_pscan
+            bt_start
+            sixad_start
+        else
+            if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
+            echo "Watchdog: hci0 down, re-enabling."
+                bt_device_enable
+            fi
         fi
         sleep 5;
     done
-    sixad_start
 }
 
 sixad_start () {
+    REMOTE=0
     bt_device_check
-    bt_start_and_stop
-    env sleep 1
-    $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
-    env sleep 2
-    bt_device_enable
-    sixad_watchdog
+    if (sixad_running_check); then
+        echo "sixad is already running."
+        echo "run '$0 --stop' to stop it"
+    else
+        if (modprobe_check); then  #Check for root access before running, If NO access, quit
+            bt_start_and_stop
+            env sleep 1
+            $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
+            env sleep 2
+            sixad_watchdog
+        else
+            echo "You need admin/root access to run this application"
+        fi
+    fi
+    bt_device_enable 
 }
 
 case $1 in
+
   --start|-start|start|-s)
-#boot error fix attempt.
-REMOTE=0
-bt_device_check
-if (sixad_running_check); then
-  echo "sixad is already running."
-  echo "run '$0 --stop' to stop it"
-else
-  if (modprobe_check); then  #Check for root access before running, If NO access, quit
-    sixad_start
-  else
-    echo "You need admin/root access to run this application"
-  fi
-fi
+sixad_start
   ;;
 
   --stop|-stop|stop)
@@ -164,6 +152,7 @@ if (modprobe_check); then  #Check for root access before running, If NO access, 
 else
   echo "You need admin/root access to run this application"
 fi
+bt_device_enable
   ;;
 
   --restore|-restore|restore|-r)

--- a/sixad
+++ b/sixad
@@ -42,11 +42,20 @@ if (which hciconfig > /dev/null); then
     echo "You're using a _really_ old bluetooth dongle,"
     echo "the Sixaxis will just not work!"
   fi
+  bt_device_enable
 fi
 }
 
 bt_device_enable () {
+bt_device_up
+bt_device_pscan
+}
+
+bt_device_up () {
 hciconfig hci0 up
+}
+
+bt_device_pscan () {
 hciconfig hci0 pscan
 }
 
@@ -94,42 +103,45 @@ sixad_watchdog (){
             $SUDO pkill -KILL sixad-sixaxis
             $SUDO pkill -KILL sixad-remote
             $SUDO pkill -TERM sixad-bin
-            bt_start
-            sixad_start
-        else
-            if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
-            echo "Watchdog: hci0 down, re-enabling."
-                bt_device_enable
-            fi
+            break
+        fi
+        if (hciconfig hci0 | grep "DOWN" &> /dev/null); then
+          echo "Watchdog: hci0 down, re-enabling."
+          bt_device_up
+        fi
+        if ! (hciconfig hci0 | grep "PSCAN" &> /dev/null); then
+         bt_device_pscan
         fi
         sleep 5;
     done
+    sixad_start
 }
 
 sixad_start () {
-    REMOTE=0
     bt_device_check
-    if (sixad_running_check); then
-        echo "sixad is already running."
-        echo "run '$0 --stop' to stop it"
-    else
-        if (modprobe_check); then  #Check for root access before running, If NO access, quit
-            bt_start_and_stop
-            env sleep 1
-            $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
-            env sleep 2
-            sixad_watchdog
-        else
-            echo "You need admin/root access to run this application"
-        fi
-    fi
-    bt_device_enable 
+    bt_start_and_stop
+    env sleep 1
+    $SUDO /usr/sbin/sixad-bin $DEBUG $LEGACY $REMOTE &
+    env sleep 2
+    bt_device_enable
+    sixad_watchdog
 }
 
 case $1 in
-
   --start|-start|start|-s)
-sixad_start
+#boot error fix attempt.
+REMOTE=0
+bt_device_check
+if (sixad_running_check); then
+  echo "sixad is already running."
+  echo "run '$0 --stop' to stop it"
+else
+  if (modprobe_check); then  #Check for root access before running, If NO access, quit
+    sixad_start
+  else
+    echo "You need admin/root access to run this application"
+  fi
+fi
   ;;
 
   --stop|-stop|stop)
@@ -152,7 +164,6 @@ if (modprobe_check); then  #Check for root access before running, If NO access, 
 else
   echo "You need admin/root access to run this application"
 fi
-bt_device_enable
   ;;
 
   --restore|-restore|restore|-r)


### PR DESCRIPTION
Added a watchdog for PSCAN, separated redundant functions and added them to where they are needed. May have redundant "bt_device_enable" functions but it works every time without adding in delays. (Maybe having a system where more devices and drivers are starting at times causes sixad to launch without the  btdevice being initialized. Although that wouldnt explain why PSCAN wasn't being set while the device was up and sixad-bin was running. Which is why i added a watchdog to the attribute. I'd like to stay away from simply sleeping.
