### PR TITLE
No frills behavior for Dualshock 3

### DIFF
--- a/default
+++ b/default
@@ -7,7 +7,7 @@ enable_timeout 1
 timeout_mins 10
 led_n_auto 1
 led_n_number 0
-led_anim 1
+led_anim 0
 enable_buttons 1
 enable_sbuttons 0
 enable_axis 1

--- a/sixad-sixaxis.cpp
+++ b/sixad-sixaxis.cpp
@@ -381,7 +381,6 @@ int main(int argc, char *argv[])
         uinput_close(ufd->mk, debug);
     }
 
-    do_rumble(csk, 10, 0xff, 0xff, 0x01);
     usleep(10*1000);
     
     delete ufd;


### PR DESCRIPTION
This removes the LED animation and heavy rumble when turning on a Duslshock 3 controller. I found the rumble especially annoying and pointless. This way the joypad behaves like it does on the PlayStation 3.